### PR TITLE
Replicate dagger nullable issue

### DIFF
--- a/app/src/main/java/com/example/anvilissuereplicate/AnvilAndroidInjector.kt
+++ b/app/src/main/java/com/example/anvilissuereplicate/AnvilAndroidInjector.kt
@@ -4,7 +4,7 @@ import com.squareup.anvil.annotations.ContributesTo
 import dagger.BindsInstance
 import dagger.MembersInjector
 
-interface AnvilAndroidInjector<T: Any> {
+interface AnvilAndroidInjector<T> {
 
     val injector: MembersInjector<T>
 
@@ -12,7 +12,7 @@ interface AnvilAndroidInjector<T: Any> {
         injector.injectMembers(target)
     }
 
-    interface Factory<T : Any> {
+    interface Factory<T> {
         fun create(@BindsInstance instance: T): AnvilAndroidInjector<T>
     }
 }


### PR DESCRIPTION
### Context
- `main` branch is able to be built
- `dagger-nullable-issue` branch is the setup we have in bandlab (without specifying `T : Any`)

### Issue
Without letting T extending Any, build failed with the following error

```
[ksp] /Users/kevin/Documents/AnvilIssueReplicate/app/build/generated/ksp/debug/kotlin/com/example/anvilissuereplicate/MergedAppComponent.kt:27: [Dagger/Nullable] com.example.anvilissuereplicate.MainActivity is not nullable, but is being provided by com.example.anvilissuereplicate.AnvilAndroidInjector.Factory.create(instance)
    com.example.anvilissuereplicate.MainActivity is injected at
        com.example.anvilissuereplicate.MainActivityModule.provideLifecycle(activity)
    androidx.lifecycle.Lifecycle is injected at
        com.example.anvilissuereplicate.Logger(lifecycle)
    com.example.anvilissuereplicate.Logger is injected at
        com.example.anvilissuereplicate.MainActivity.logger
    dagger.MembersInjector<com.example.anvilissuereplicate.MainActivity> is requested at
        com.example.anvilissuereplicate.AnvilAndroidInjector.getInjector() [com.example.anvilissuereplicate.MergedAppComponent → com.example.anvilissuereplicate.MergedMainActivitySubcomponent]
```