### PR TITLE
Remove explicit subcomponent factory exposure

### DIFF
--- a/app/src/main/java/com/example/anvilissuereplicate/MainActivitySubcomponent.kt
+++ b/app/src/main/java/com/example/anvilissuereplicate/MainActivitySubcomponent.kt
@@ -33,8 +33,3 @@ interface MainActivityInjectorBinder {
     fun bindMainActivityAnvilInjector(`impl`: MainActivitySubcomponent.Factory):
             AnvilAndroidInjector.Factory<*>
 }
-
-@ContributesTo(scope = AppScope::class)
-interface MainActivityFactoryProvider {
-    fun provideMainActivityFactory(): MainActivitySubcomponent.Factory
-}


### PR DESCRIPTION
### Context
- `main` branch is able to be built
- `subcomponent-factory-exposure` branch removes the subcomponent factory exposure

### Issue
```
> Task :app:kspDebugKotlin FAILED
e: [ksp] /Users/kevin/Documents/anvil-issue-replicate/app/build/generated/ksp/debug/kotlin/com/example/anvilissuereplicate/MergedAppComponent.kt:26: [Dagger/MissingBinding] com.example.anvilissuereplicate.MainActivitySubcomponent.Factory cannot be provided without an @Provides-annotated method.

    com.example.anvilissuereplicate.MainActivitySubcomponent.Factory is injected at
        [com.example.anvilissuereplicate.MergedAppComponent] com.example.anvilissuereplicate.MainActivityInjectorBinder.bindMainActivityAnvilInjector(impl)
    java.util.Map<java.lang.Class<?>,com.example.anvilissuereplicate.AnvilAndroidInjector.Factory<?>> is requested at
        [com.example.anvilissuereplicate.MergedAppComponent] com.example.anvilissuereplicate.AnvilAndroidInjectorProvider.dispatchingAnvilInjector()
e: Error occurred in KSP, check log for detail
```